### PR TITLE
Don't log warnings for all 404 errors.

### DIFF
--- a/src/OpenSearchClientFactory.php
+++ b/src/OpenSearchClientFactory.php
@@ -27,6 +27,11 @@ final class OpenSearchClientFactory
         $clientBuilder = new ClientBuilder();
         $clientBuilder->setHosts($config['hosts']);
         $clientBuilder->setLogger($logger);
+        $clientBuilder->setConnectionParams([
+            'client' => [
+                'ignore' => [404],
+            ],
+        ]);
 
         if (isset($config['username'], $config['password'])) {
             $clientBuilder->setBasicAuthentication($config['username'], $config['password']);


### PR DESCRIPTION
404 warnings are currently spamming most of the logs. Even when everywhere in the code is checked correctly if an index, alias or document exists the bundle logs a 404 error by default. This PR silents down those 404 warnings.