### PR TITLE
fix: allow react/promise ^3.0 composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "~8.4.0 || ~8.5.0",
     "pimcore/pimcore": "^2026.1",
     "opensearch-project/opensearch-php": "^2.2.0",
-    "react/promise": "^2.11"
+    "react/promise": "^2.11 || ^3.0"
   },
   "conflict": {
     "opensearch-project/opensearch-php": ">=2.4"


### PR DESCRIPTION
The Composer requirement react/promise was restricted to ^2.11, which might conflict with other dependencies requiring version 3. An example is (latest version of) composer/composer which in turn is used within composer plugins installed in the project.

Resolved with: allowing both ^2.11 and ^3.0 within the composer requirements

Resolves #42
