### PR TITLE
[Documentation] Correct OpenSearch compatibility table and note OpenSearch 3 is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It allows to configure one or more Opensearch clients with different configurati
 
 | Pimcore Client Version | OpenSearch Version |
 |------------------------|--------------------|
-| 1.x - 2026.x           | >= 1.0, < 3.0      |
+| >= 1.0                 | >= 1.0, < 3.0      |
 
 OpenSearch 3 is not supported yet: all client versions ship the
 `opensearch-project/opensearch-php` client in version `^2.2`, which targets

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ It allows to configure one or more Opensearch clients with different configurati
 
 | Pimcore Client Version | OpenSearch Version |
 |------------------------|--------------------|
-| 1.0.0                  | 1.0.0-2.1.0        |
+| 1.x - 2026.x           | >= 1.0, < 3.0      |
+
+OpenSearch 3 is not supported yet: all client versions ship the
+`opensearch-project/opensearch-php` client in version `^2.2`, which targets
+OpenSearch 1.x and 2.x servers.
 
 ## Documentation Overview
 - [Installation](./doc/01_Installation.md)


### PR DESCRIPTION
## Changes in this pull request

The README compatibility table was stale on all branches — it only listed client `1.0.0` with OpenSearch `1.0.0-2.1.0`, which understates OpenSearch 2.x support and says nothing about OpenSearch 3.

Updated to the accurate range: all client versions require `opensearch-project/opensearch-php ^2.2`, which targets OpenSearch 1.x/2.x servers — so **`>= 1.0, < 3.0`**, with an explicit note that OpenSearch 3 is not supported yet.

## Additional info

- Companion to pimcore/generic-data-index-bundle#463 (same clarification in the GDI docs), both prompted by pimcore/generic-data-index-bundle#430 where a user ran OpenSearch 3.7.
- The old table is byte-identical on all maintained branches, so the forward merge up the chain will be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)